### PR TITLE
Replacing createError w/ createErrorFromThrowable

### DIFF
--- a/Interactor/ElasticApmInteractor.php
+++ b/Interactor/ElasticApmInteractor.php
@@ -47,7 +47,7 @@ class ElasticApmInteractor implements ElasticApmInteractorInterface
 
     public function noticeThrowable(\Throwable $e, string $message = null): void
     {
-        ElasticApm::createError($e);
+        ElasticApm::createErrorFromThrowable($e);
     }
 
     public function beginTransaction(string $name, string $type, ?float $timestamp = null, ?DistributedTracingData $distributedTracingData = null): ?TransactionInterface


### PR DESCRIPTION
In the latest version of elastic apm extension the createError method was renamed to createErrorFromThrowable

https://github.com/elastic/apm-agent-php/blob/master/src/ElasticApm/ElasticApm.php#L175