### PR TITLE
Replace deprecated KernelEvent::isMasterRequest()

### DIFF
--- a/Listener/ResponseListener.php
+++ b/Listener/ResponseListener.php
@@ -41,11 +41,16 @@ class ResponseListener implements EventSubscriberInterface
 
     public function onKernelResponse(KernelResponseEvent $event): void
     {
-        if (! $event->isMasterRequest()) {
+        if (! $this->isMainRequest($event)) {
             return;
         }
 
         $this->interactor->addContextFromConfig();
+    }
+
+    private function isMainRequest(KernelResponseEvent $event): bool
+    {
+        return method_exists($event, 'isMainRequest') ? $event->isMainRequest() : $event->isMasterRequest();
     }
 }
 


### PR DESCRIPTION
This was deprecated in Symfony 5.3, see https://github.com/symfony/symfony/blob/5.3/UPGRADE-5.3.md#httpkernel and https://github.com/symfony/symfony/pull/40536

This fix provides full backwards compatibility.